### PR TITLE
 submodules line added to core.mk

### DIFF
--- a/core.mk
+++ b/core.mk
@@ -15,6 +15,11 @@ UART_SUBMODULES_DIR:=$(UART_DIR)/submodules
 LIB_DIR ?= $(UART_SUBMODULES_DIR)/LIB
 TEX_DIR ?= $(UART_SUBMODULES_DIR)/TEX
 
+#submodules
+UART_SUBMODULES:=INTERCON LIB TEX
+$(foreach p, $(UART_SUBMODULES), $(eval $p_DIR:=$(UART_DIR)/submodules/$p))
+
+
 REMOTE_ROOT_DIR ?= sandbox/iob-soc/submodules/UART
 
 #


### PR DESCRIPTION
To fix the error :  *** No rule to make target '/hardware/include/gen_if.v', needed by 'gen_is_tab.tex'.  Stop.
I added submodules line to the core.mk file and it worked. 