### PR TITLE
Added UARTsw_reg.v in VHDR list for Skywater req by OpenLane

### DIFF
--- a/hardware/hardware.mk
+++ b/hardware/hardware.mk
@@ -16,7 +16,7 @@ INCLUDE+=$(incdir)$(UART_INC_DIR)
 
 #included files
 VHDR+=$(wildcard $(UART_INC_DIR)/*.vh)
-VHDR+=UARTsw_reg_gen.v UARTsw_reg.vh UARTsw_reg.v #UARTsw_reg.v added for skywater
+VHDR+=UARTsw_reg_gen.v UARTsw_reg.vh UARTsw_reg.v 
 #sources
 VSRC+=$(UART_SRC_DIR)/uart_core.v $(UART_SRC_DIR)/iob_uart.v
 

--- a/hardware/hardware.mk
+++ b/hardware/hardware.mk
@@ -16,7 +16,7 @@ INCLUDE+=$(incdir)$(UART_INC_DIR)
 
 #included files
 VHDR+=$(wildcard $(UART_INC_DIR)/*.vh)
-VHDR+=UARTsw_reg_gen.v UARTsw_reg.vh
+VHDR+=UARTsw_reg_gen.v UARTsw_reg.vh UARTsw_reg.v #UARTsw_reg.v added for skywater
 #sources
 VSRC+=$(UART_SRC_DIR)/uart_core.v $(UART_SRC_DIR)/iob_uart.v
 


### PR DESCRIPTION
Hi,
I have added  UARTsw_reg.v to VHDR list as this is required by OpenLane.
Kindly have a look
regards