### PR TITLE
Update LIB with mkregs refactor

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -32,8 +32,8 @@ $(TOP_MODULE)_version.txt:
 	echo $(VERSION) > version.txt
 
 #cpu accessible registers
-iob_uart_swreg_def.vh iob_uart_swreg_gen.vh: $(UART_HW_DIR)/include/iob_uart_swreg.vh
-	$(MKREGS) $< HW
+iob_uart_swreg_def.vh iob_uart_swreg_gen.vh: $(UART_DIR)/mkregs.conf
+	$(MKREGS) iob_uart $(UART_DIR) HW
 
 uart-gen-clean:
 	@rm -rf *# *~ version.txt

--- a/document/document.mk
+++ b/document/document.mk
@@ -18,7 +18,6 @@ export DEFINE
 
 VHDR+=$(LIB_DIR)/hardware/include/gen_if.vh
 VHDR+=$(LIB_DIR)/hardware/include/iob_s_if.vh
-VHDR+=$(UART_DIR)/hardware/include/iob_uart_swreg.vh
 
 #INCLUDE TEX SUBMODULE MAKEFILE SEGMENT
 include $(LIB_DIR)/document/document.mk

--- a/document/document.mk
+++ b/document/document.mk
@@ -12,6 +12,7 @@ XIL_FAMILY ?=XCKU
 #PREPARE TO INCLUDE TEX SUBMODULE MAKEFILE SEGMENT
 #root directory
 CORE_DIR:=$(UART_DIR)
+MKREGS_CONF:=$(UART_DIR)/mkregs.conf
 
 #export definitions
 export DEFINE

--- a/hardware/include/iob_uart_swreg.vh
+++ b/hardware/include/iob_uart_swreg.vh
@@ -1,9 +1,0 @@
-//START_SWREG_TABLE uart
-`IOB_SWREG_W(UART_SOFTRESET, 1, 0) //Bit duration in system clock cycles.
-`IOB_SWREG_W(UART_DIV, 16, 0) //Bit duration in system clock cycles.
-`IOB_SWREG_W(UART_TXDATA, 8, 0) //TX data
-`IOB_SWREG_W(UART_TXEN, 1, 0) //TX enable.
-`IOB_SWREG_R(UART_TXREADY, 1, 0) //TX ready to receive data
-`IOB_SWREG_R(UART_RXDATA, 8, 0) //RX data
-`IOB_SWREG_W(UART_RXEN, 1, 0) //RX enable.
-`IOB_SWREG_R(UART_RXREADY, 1, 0) //RX data is ready to be read.

--- a/hardware/src/iob_uart.v
+++ b/hardware/src/iob_uart.v
@@ -25,7 +25,6 @@ module iob_uart
    );
 
 //BLOCK Register File & Configuration control and status register file.
-`include "iob_uart_swreg.vh"
 `include "iob_uart_swreg_gen.vh"
    
    uart_core uart_core0 

--- a/mkregs.conf
+++ b/mkregs.conf
@@ -1,0 +1,9 @@
+//START_SWREG_TABLE uart
+IOB_SWREG_W(UART_SOFTRESET, 1, 0) //Bit duration in system clock cycles.
+IOB_SWREG_W(UART_DIV, 16, 0) //Bit duration in system clock cycles.
+IOB_SWREG_W(UART_TXDATA, 8, 0) //TX data
+IOB_SWREG_W(UART_TXEN, 1, 0) //TX enable.
+IOB_SWREG_R(UART_TXREADY, 1, 0) //TX ready to receive data
+IOB_SWREG_R(UART_RXDATA, 8, 0) //RX data
+IOB_SWREG_W(UART_RXEN, 1, 0) //RX enable.
+IOB_SWREG_R(UART_RXREADY, 1, 0) //RX data is ready to be read.

--- a/software/iob-uart.c
+++ b/software/iob-uart.c
@@ -3,41 +3,41 @@
 
 //TX FUNCTIONS
 void uart_txwait() {
-    while(!UART_GET_TXREADY());
+    while(!IOB_UART_GET_TXREADY());
 }
 
 void uart_putc(char c) {
-    while(!UART_GET_TXREADY());
-    UART_SET_TXDATA(c);
+    while(!IOB_UART_GET_TXREADY());
+    IOB_UART_SET_TXDATA(c);
 }
 
 //RX FUNCTIONS
 void uart_rxwait() {
-    while(!UART_GET_RXREADY());
+    while(!IOB_UART_GET_RXREADY());
 }
 
 char uart_getc() {
-    while(!UART_GET_RXREADY());
-    return UART_GET_RXDATA();
+    while(!IOB_UART_GET_RXREADY());
+    return IOB_UART_GET_RXDATA();
 }
 
 //UART basic functions
 void uart_init(int base_address, uint16_t div) {
   //capture base address for good
-  UART_INIT_BASEADDR(base_address);
+  IOB_UART_INIT_BASEADDR(base_address);
   
   //pulse soft reset
-  UART_SET_SOFTRESET(1);
-  UART_SET_SOFTRESET(0);
+  IOB_UART_SET_SOFTRESET(1);
+  IOB_UART_SET_SOFTRESET(0);
 
   //Set the division factor div
   //div should be equal to round (fclk/baudrate)
-  //E.g for fclk = 100 Mhz for a baudrate of 115200 we should UART_SET_DIV(868)
-  UART_SET_DIV(div);
+  //E.g for fclk = 100 Mhz for a baudrate of 115200 we should IOB_UART_SET_DIV(868)
+  IOB_UART_SET_DIV(div);
 
   //enable TX and RX
-  UART_SET_TXEN(1);
-  UART_SET_RXEN(1);
+  IOB_UART_SET_TXEN(1);
+  IOB_UART_SET_RXEN(1);
 }
 
 void uart_finish() {

--- a/software/pc-emul/iob_uart_swreg_pc_emul.c
+++ b/software/pc-emul/iob_uart_swreg_pc_emul.c
@@ -7,12 +7,12 @@
 
 static uint16_t div_value;
 
-void UART_INIT_BASEADDR(uint32_t addr) {
+void IOB_UART_INIT_BASEADDR(uint32_t addr) {
     base = addr;
     return;
 }
 
-void UART_SET_SOFTRESET(uint8_t value) {
+void IOB_UART_SET_SOFTRESET(uint8_t value) {
     //manage files to communicate with console here
     FILE *cnsl2soc_fd;
 
@@ -23,12 +23,12 @@ void UART_SET_SOFTRESET(uint8_t value) {
     return;
 }
 
-void UART_SET_DIV(uint16_t value) {
+void IOB_UART_SET_DIV(uint16_t value) {
     div_value = value;
     return;
 }
 
-void UART_SET_TXDATA(uint8_t value) {
+void IOB_UART_SET_TXDATA(uint8_t value) {
     // send byte to console
     char aux_char;
     int able2read;
@@ -49,19 +49,19 @@ void UART_SET_TXDATA(uint8_t value) {
     }
 }
 
-void UART_SET_TXEN(uint8_t value) {
+void IOB_UART_SET_TXEN(uint8_t value) {
     return;
 }
 
-void UART_SET_RXEN(uint8_t value) {
+void IOB_UART_SET_RXEN(uint8_t value) {
     return;
 }
 
-uint8_t UART_GET_TXREADY() {
+uint8_t IOB_UART_GET_TXREADY() {
     return 1;
 }
 
-uint8_t UART_GET_RXDATA() {
+uint8_t IOB_UART_GET_RXDATA() {
     //get byte from console
     char c;
     int able2write;
@@ -83,6 +83,6 @@ uint8_t UART_GET_RXDATA() {
     return (int64_t) c;
 }
 
-uint8_t UART_GET_RXREADY() {
+uint8_t IOB_UART_GET_RXREADY() {
     return 1;
 }

--- a/software/software.mk
+++ b/software/software.mk
@@ -11,5 +11,5 @@ HDR+=$(UART_SW_DIR)/*.h iob_uart_swreg.h
 #sources
 SRC+=$(UART_SW_DIR)/iob-uart.c
 
-iob_uart_swreg.h: $(UART_HW_DIR)/include/iob_uart_swreg.vh
-	$(MKREGS) $< SW UART
+iob_uart_swreg.h: 
+	$(MKREGS) iob_uart $(UART_DIR) SW 


### PR DESCRIPTION
- update LIB submodule
- LIB update requires some changes:
  - replace `iob_uart_swreg.vh` file with `mkregs.conf` in root directory
  - add `MKREGS_CONF` variable to `document/document.mk` with path to
    `mkregs.conf` file
  - update `mkregs.py` script calls (see `mkregs.py --help` for more
    details)
  - update software drivers to use `IOB_UART` instead of `UART` only