### PR TITLE
feat(mkregs): update LIB, ignore address 2 LSBs

### DIFF
--- a/hardware/include/inst.vh
+++ b/hardware/include/inst.vh
@@ -16,7 +16,7 @@
       .clk       (clk),
       .rst       (reset),
       .valid(slaves_req[`valid(`UART)]),
-      .address(slaves_req[`address(`UART,`iob_uart_swreg_ADDR_W)]),
+      .address(slaves_req[`address(`UART,`iob_uart_swreg_ADDR_W+2)-2]),
       .wdata(slaves_req[`wdata(`UART)]),
       .wstrb(slaves_req[`wstrb(`UART)]),
       .rdata(slaves_resp[`rdata(`UART)]),

--- a/hardware/src/iob_uart.v
+++ b/hardware/src/iob_uart.v
@@ -109,7 +109,7 @@ module iob_uart
       .tx_data(UART_TXDATA),
       .rx_data(UART_RXDATA_rdata),
       .data_write_en(UART_TXDATA_en),
-      .data_read_en(valid & !wstrb & (address == `UART_RXDATA_ADDR)),
+      .data_read_en(valid & !wstrb & (address == (`UART_RXDATA_ADDR >> 2))),
       .bit_duration(UART_DIV),
       .rxd(rxd),
       .txd(txd),


### PR DESCRIPTION
- update LIB submodule
- ignore 2 least significant bits from cpu address
- see IObundle/iob-lib#103