### PR TITLE
fix(pc-emul): check existing file via open to read

### DIFF
--- a/software/pc-emul/iob_uart_swreg_pc_emul.c
+++ b/software/pc-emul/iob_uart_swreg_pc_emul.c
@@ -23,7 +23,7 @@ void IOB_UART_INIT_BASEADDR(uint32_t addr) {
   //wait for console to create communication files 
   while ((cnsl2soc_fd = fopen("./cnsl2soc", "rb")) == NULL);
   fclose(cnsl2soc_fd);
-  while ((soc2cnsl_fd = fopen("./soc2cnsl", "wb"))==NULL);;
+  while ((soc2cnsl_fd = fopen("./soc2cnsl", "rb"))==NULL);
   fclose(soc2cnsl_fd);
 
   base = addr;


### PR DESCRIPTION
- pc-emul implementation should open the `soc2cnsl` file to read,
  otherwise opening file to write creates a new file
- this can cause problems if the pc-emul implementation:
    1. creates the `soc2cnsl` file first
    2. resumes firmware operation by starting to write data to the file
    3. then later, the `console` re-creates the `soc2cnsl` file again
       via `init_files()`.
    - this case efectively causes the loss of a character sent via UART.