### PR TITLE
fix(version): update LIB, generate version vh file

### DIFF
--- a/hardware/hardware.mk
+++ b/hardware/hardware.mk
@@ -18,6 +18,12 @@ UART_INC_DIR:=$(UART_DIR)/hardware/include
 UART_SRC_DIR:=$(UART_DIR)/hardware/src
 
 #HEADERS
+
+SRC+=$(BUILD_VSRC_DIR)/$(NAME)_version.vh
+$(BUILD_VSRC_DIR)/$(NAME)_version.vh:
+	$(LIB_DIR)/software/python/version.py -v $(CORE_DIR)
+	mv $(NAME)_version.vh $(BUILD_VSRC_DIR)
+
 SRC+=$(subst $(UART_INC_DIR), $(BUILD_VSRC_DIR), $(wildcard $(UART_INC_DIR)/*.vh))
 $(BUILD_VSRC_DIR)/%.vh: $(UART_INC_DIR)/%.vh
 	cp $< $(BUILD_VSRC_DIR)


### PR DESCRIPTION
- update LIB submodule
- target to generate iob_uart_version.vh file in `hardware.mk`
- see IObundle/iob-lib#167