### PR TITLE
feat(LIB): Update LIB and iob_uart_setup.py accordingly

### DIFF
--- a/iob_uart_setup.py
+++ b/iob_uart_setup.py
@@ -7,8 +7,9 @@ import setup
 name='iob_uart'
 version='V0.10'
 flows='sim emb'
-setup_dir=os.path.dirname(__file__)
-build_dir=f"../{name}_{version}"
+if setup.is_top_module(sys.modules[__name__]):
+    setup_dir=os.path.dirname(__file__)
+    build_dir=f"../{name}_{version}"
 submodules = {
     'hw_setup': {
         'headers' : [ 'iob_s_port', 'iob_s_portmap' ],


### PR DESCRIPTION
The setup and build directories should only be set if the module is not being imported by another (if the module is not the top module).