### PR TITLE
feat(setup): Use new setup process: Call iob_uart.py directly. 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,22 @@
 CORE := iob_uart
 DISABLE_LINT:=1
-include submodules/LIB/setup.mk
 
-sim-build: clean
+clean:
 	rm -rf ../$(CORE)_V*
-	make setup && make -C ../$(CORE)_V*/ sim-build
 
-sim-run: clean
-	rm -rf ../$(CORE)_V*
-	make setup && make -C ../$(CORE)_V*/ sim-run
+setup:
+	python3 -B ./$(CORE).py
+
+sim-build: clean setup
+	make -C ../$(CORE)_V*/ sim-build
+
+sim-run: clean setup
+	make -C ../$(CORE)_V*/ sim-run
 
 sim-waves:
 	make -C ../$(CORE)_V*/ sim-waves
 
-sim-test: clean
-	rm -rf ../$(CORE)_V*
-	make setup && make -C ../$(CORE)_V*/ sim-test
+sim-test: clean setup
+	make -C ../$(CORE)_V*/ sim-test
 
 

--- a/iob_uart.py
+++ b/iob_uart.py
@@ -2,7 +2,12 @@
 
 import os
 
-from iob_module import iob_module
+if __name__ == "__main__":
+    # Find python modules
+    import sys
+    sys.path.append("./submodules/LIB/scripts")
+    from iob_module import iob_module
+    iob_module.find_modules()
 
 # Submodules
 from iob_utils import iob_utils
@@ -200,3 +205,7 @@ class iob_uart(iob_module):
     @classmethod
     def _setup_block_groups(cls):
         cls.block_groups += []
+
+
+if __name__ == "__main__":
+    iob_uart.setup_as_top_module()

--- a/iob_uart.py
+++ b/iob_uart.py
@@ -2,11 +2,12 @@
 
 import os
 
+# Find python modules
 if __name__ == "__main__":
-    # Find python modules
     import sys
     sys.path.append("./submodules/LIB/scripts")
-    from iob_module import iob_module
+from iob_module import iob_module
+if __name__ == "__main__":
     iob_module.find_modules()
 
 # Submodules


### PR DESCRIPTION
New setup process no longer uses setup.mk or bootstrap.py
The user calls `python3 -B ./iob_uart.py` directly to intiate the setup process
(create the build dir).
Checkout the contents of the Makefile for examples.