### PR TITLE
Add correct port widths for generated iob interface.

### DIFF
--- a/iob_uart.py
+++ b/iob_uart.py
@@ -69,6 +69,10 @@ class iob_uart(iob_module):
                 "wire_prefix": "",
                 "descr": "CPU native interface",
                 "ports": [],
+                "widths": {
+                    "ADDR_W": "ADDR_W",
+                    "DATA_W": "DATA_W",
+                },
             },
             {
                 "name": "rs232",


### PR DESCRIPTION
Add `widths` dictionary to configure generated iob interface with port widths based on UART parameters.